### PR TITLE
Set version to 0.3.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "byte",
     "64"
   ],
-  "version": "1.0.0",
+  "version": "0.3.5",
   "author": "Nathan Rajlich <nathan@tootallnate.net> (http://tootallnate.net)",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Using version 1.0.0 is breaking "npm install appbuilder" and "npm install nativescript" on Windows where Visual Studio is not installed. Using version 1.0.0 is causing another dependency (ref-struct) to try using another version of ref (not this one) and trying to rebuild it. In case the machine do not have several building tools (python, Visual Studio 2010) this breaks the installation.